### PR TITLE
衣装の商品名変更に追従

### DIFF
--- a/data/clothes.toml
+++ b/data/clothes.toml
@@ -454,7 +454,7 @@ author = "ふぉいショップ"
 url = "https://booth.pm/ja/items/2654391"
 
 [[cloth]]
-name = "シンプルワンピース"
+name = "海夏ワンピース"
 author = "ラケシア洋裁"
 url = "https://booth.pm/ja/items/2589918"
 


### PR DESCRIPTION
## 衣装の商品名変更に追従

【７モデル対応】海夏ワンピース
https://booth.pm/ja/items/2589918

>※ゼロから制作した為、当BOOTHで扱っている「【メリノちゃん専用】 掴めるシンプルワンピース ( https://lachexia.booth.pm/items/2370770 ) 」とは見た目のシルエットや布の量、頂点数など完全な別物となっております。
追記：紛らわしいので名前を変更しました。