### PR TITLE
各コンテンツページのヘッダ文字色がリンク遷移後の色に変化してしまっている点の修正

### DIFF
--- a/assets/style/style.scss
+++ b/assets/style/style.scss
@@ -94,6 +94,13 @@ rt {
   display: flex;
   justify-content: center;
   align-items: center;
+
+  a:hover,
+  a:focus,
+  a:active,
+  a:visited {
+    color: inherit;
+  }
 }
 
 .heroHeader {


### PR DESCRIPTION
- now
![image](https://user-images.githubusercontent.com/22709248/120885021-97ec5380-c621-11eb-8e5c-e3efaadbbb25.png)
- after
![image](https://user-images.githubusercontent.com/22709248/120885041-b0f50480-c621-11eb-9a09-8aee700d6840.png)

heroHeader classに後ほどリファクタ予定っぽいですが、
たまたま今でプロイされているものを見て気付いたので。